### PR TITLE
fix(git-stale): allow opening repository from env

### DIFF
--- a/bin/stale.rs
+++ b/bin/stale.rs
@@ -121,7 +121,7 @@ impl Command {
 
 impl Cli {
     fn to_command(self) -> Result<Command, Box<dyn Error>> {
-        let repo = Repository::open(".")?;
+        let repo = Repository::open_from_env()?;
         let now = Local::now();
         let since = self.since.map(|s| now - s);
 


### PR DESCRIPTION
Fixing error caused by invoking `git-stale` from subdirectory:

```
Error: Error { code: -3, klass: 6, message: "could not find repository at '.'" }
```
