### PR TITLE
chore(workflows): allow comment on issues

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     needs:
       - get-next-version
       - test


### PR DESCRIPTION
Grant `issues: write` permission to semantic-release-action at release job on release workflow.