### PR TITLE
fix: static link libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +417,7 @@ checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "bin/whose.rs"
 chrono = "0.4.38"
 clap = { version = "4.5.13", features = ["derive"] }
 env_logger = "0.11.5"
-git2 = "0.19.0"
+git2 = { version = "0.19.0", features = ["vendored-libgit2", "vendored-openssl"] }
 log = "0.4.22"
 once_cell = "1.19.0"
 regex = "1.10.6"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,0 @@
-[build]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"
-]


### PR DESCRIPTION
enable vendored-libgit2 and vendored-openssl features for git2, to enable cross compilation targeting aarch64-unknown-linux-gnu.