### PR TITLE
refactor(git-whose): prefer `try_from_*` naming

### DIFF
--- a/bin/whose.rs
+++ b/bin/whose.rs
@@ -55,7 +55,7 @@ impl Cli {
             pathname::normalize_paths(&repo, self.pathspecs)?
         };
 
-        let codeowners = CodeOwners::new(&repo)?;
+        let codeowners = CodeOwners::try_from_repo(&repo)?;
 
         Ok(Command {
             repo,


### PR DESCRIPTION
Preferring `try_from_*` naming for factory function returning Result, renames `CodeOwners::new` to `CodeOwners::try_from_repo`.