### PR TITLE
chore: update Cargo.toml when updating dependencies

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,17 @@
+name: Renovate
+on:
+  pull_request:
+    paths:
+      - renovate.json
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            renovate.json
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ path = "bin/whose.rs"
 
 [dependencies]
 chrono = "0.4.38"
-clap = { version = "4.5.13", features = ["derive"] }
+clap = { version = "4.5.21", features = ["derive"] }
 env_logger = "0.11.5"
 git2 = { version = "0.19.0", features = ["vendored-libgit2", "vendored-openssl"] }
 log = "0.4.22"
 once_cell = "1.19.0"
-regex = "1.10.6"
+regex = "1.11.1"
 thiserror = "2.0.0"
 
 [dev-dependencies]

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,5 @@
       "automerge": true
     }
   ],
-  "rangeStrategy": "update-lockfile"
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
- Updates Cargo.toml with versions in lockfile
- Changes rangeStrategy to bump, to let Renovate update Cargo.toml too
- Adds CI gate to validate renovate.json
