### PR TITLE
chore: use stable channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.0"
+channel = "stable"
 components = ["rustc", "cargo", "rustfmt", "clippy"]
 profile = "minimal"
 targets = []


### PR DESCRIPTION
changes channel to stable from 1.77.0
