### PR TITLE
Implement git dah

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +229,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "git-toolbox"
 version = "2.0.5"
 dependencies = [
@@ -235,6 +254,7 @@ dependencies = [
  "regex",
  "tempfile",
  "thiserror",
+ "ulid",
 ]
 
 [[package]]
@@ -435,6 +455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +479,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -560,6 +619,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "ulid"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
+dependencies = [
+ "getrandom",
+ "rand",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +672,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -656,6 +732,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "windows-core"
@@ -747,3 +833,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ homepage = "https://github.com/oakcask/git-toolbox"
 license = "MIT OR Apache-2.0"
 
 [[bin]]
+name = "git-dah"
+path = "bin/dah.rs"
+
+[[bin]]
 name = "git-stale"
 path = "bin/stale.rs"
 
@@ -22,6 +26,7 @@ log = "0.4.22"
 once_cell = "1.20.2"
 regex = "1.11.1"
 thiserror = "2.0.3"
+ulid = "1.1.3"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ Options:
   -h, --help  Print help
 ```
 
+### git-dah
+
+An alternative of git-push, knows what you want to do.
+"Dah" stands for "Fus Ro Dah" (means "force, blance, push")
+which comes from unrelenting force shout (thu'um) in Skyrim.
+
+People who are most likely to be interested in this command, are like:
+
+* Have shared repository (like GitHub repo)
+* Never push the default branch because it is always updated by
+  other process or mechanism (like Pull Requests)
+* Always search in the shell history for complex git commands:
+  branch, switch, pull, push, blah blah blah...
+
+```
+Push local changes anyway
+
+Usage: git-dah [OPTIONS]
+
+Options:
+  -1, --step           do stepwise execution
+      --limit <LIMIT>  limit number of commits to scan in history [default: 100]
+  -h, --help           Print help
+```
+
 ### Relative Date Format
 
 Some option in `git-stale` accepts relative date.

--- a/bin/dah.rs
+++ b/bin/dah.rs
@@ -1,0 +1,216 @@
+use std::{ffi::OsString, io::{self}, process::Stdio};
+
+use clap::{Parser};
+use git2::Repository;
+use git_toolbox::{
+    dah::{self, Action, GitCli, RepositoryCollector, StepResult},
+    refname::{HeadRef, RemoteRef},
+};
+use log::{error, info};
+use regex::Regex;
+use ulid::Ulid;
+
+#[derive(thiserror::Error, Debug)]
+enum DahError {
+    #[error("{command:?} failed with exit code {code:?}")]
+    ExitStatus {
+        command: OsString,
+        code: Option<i32>
+    },
+    #[error("internal error: {0}")]
+    IO(#[from] io::Error),
+    #[error("internal error: {0}")]
+    Git(#[from] git2::Error)
+}
+
+#[derive(Parser)]
+#[command(
+    about = "Push local changes anyway -- I know what you mean",
+    long_about = None)]
+struct Cli {
+    #[arg(long, short = '1', help = "Do stepwise execution")]
+    step: bool,
+    // maybe implement --ask option?
+    // #[arg(long, help = "Persistently ask before doing anything just in case")]
+    // ask: bool,
+    #[arg(
+        long,
+        help = "Increase number of commits to scan in history",
+        default_value = "100"
+    )]
+    limit: usize,
+}
+
+struct Command {
+    repo: Repository,
+    step: bool,
+    limit: usize,
+}
+
+impl Cli {
+    fn into_command(self) -> Result<Command, Box<dyn std::error::Error>> {
+        let repo = Repository::open_from_env()?;
+
+        Ok(Command {
+            repo,
+            step: self.step,
+            limit: self.limit,
+        })
+    }
+}
+
+fn get_command_line(command: &std::process::Command) -> OsString {
+    let mut cmd = command.get_program().to_owned();
+    for arg in command.get_args() {
+        cmd.push(" ");
+        cmd.push(arg);
+    }
+    cmd
+}
+
+impl Command {
+    fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        env_logger::init();
+
+        loop {
+            let collector = RepositoryCollector::new(&self.repo).with_walk_limit(self.limit);
+            let action = Action::new(collector)?;
+            match dah::step(action, &self)? {
+                StepResult::Abort { reason } => {
+                    error!("{}", reason);
+                    break;
+                }
+                StepResult::Stop => break,
+                StepResult::Continue => {
+                    if self.step {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn generate_branch_name(&self) -> Result<String, DahError> {
+        let head = self.repo.head()?;
+        let commit = head.peel_to_commit()?;
+        let mesg = commit.message().and_then(|m| m.lines().next());
+        let random = Ulid::new().to_string().to_ascii_lowercase();
+        if let Some(mesg) = mesg {
+            let mesg = Regex::new(r#"\s+"#).unwrap().replace_all(mesg, "-");
+            let mesg = Regex::new(r#"[^-\w]"#).unwrap().replace_all(&mesg, "_");
+
+            let mut mesg = mesg.into_owned();
+            mesg.push_str("-dah");
+            mesg.push_str(&random);
+            Ok(mesg)
+        } else {
+            let mut mesg = String::from("dah");
+            mesg.push_str(&random);
+            Ok(mesg)
+        }
+    }
+
+    fn run_command(&self, command: &mut std::process::Command) -> Result<(), DahError> {
+        let cmdline = get_command_line(command);
+        info!("invoking {:?}", cmdline);
+
+        command
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+
+        let status = command.status()?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(DahError::ExitStatus {
+                command: cmdline,
+                code: status.code(),
+            })
+        }
+    }
+}
+
+
+impl GitCli for Command {
+    type Error = DahError;
+
+    fn status(&self) -> Result<(), Self::Error> {
+        self.run_command(std::process::Command::new("git")
+            .arg("status")
+        )
+    }
+
+    fn create_branch_and_switch(&self) -> Result<(), Self::Error> {
+        let branch_name = self.generate_branch_name()?;
+        self.run_command(std::process::Command::new("git")
+            .arg("switch")
+            .arg("-c")
+            .arg(branch_name)
+        )
+    }
+
+    fn rename_branch_and_switch(&self) -> Result<(), Self::Error> {
+        let branch_name = self.generate_branch_name()?;
+        self.run_command(std::process::Command::new("git")
+            .arg("branch")
+            .arg("-m")
+            .arg(branch_name)
+        )
+    }
+
+    fn stage_changes(&self) -> Result<(), Self::Error> {
+        self.run_command(std::process::Command::new("git")
+            .arg("add")
+            .arg("-u")
+        )
+    }
+
+    fn commit(&self) -> Result<(), Self::Error> {
+        self.run_command(std::process::Command::new("git")
+            .arg("commit")
+        )
+    }
+
+    fn pull_with_rebase(&self, upstream_ref: &str) -> Result<(), Self::Error> {
+        // TODO: receive RemoteRef
+        let upstream_ref = RemoteRef::new(upstream_ref).unwrap();
+        self.run_command(std::process::Command::new("git")
+            .arg("pull")
+            .arg("--rebase")
+            .arg(upstream_ref.remote())
+            .arg(upstream_ref.branch())
+        )
+    }
+
+    fn push(&self, head_ref: &str, upstream_ref: Option<&str>) -> Result<(), Self::Error> {
+        let head_ref = HeadRef::new(head_ref).unwrap();
+        if let Some(upstream_ref) = upstream_ref {
+            let upstream_ref = RemoteRef::new(upstream_ref).unwrap();
+            self.run_command(std::process::Command::new("git")
+                .arg("push")
+                .arg("--force-with-lease")
+                .arg("--force-if-includes")
+                .arg("-u")
+                .arg(upstream_ref.remote())
+                .arg(head_ref.branch().unwrap())
+            )
+        } else {
+            self.run_command(std::process::Command::new("git")
+                .arg("push")
+                .arg("--force-with-lease")
+                .arg("--force-if-includes")
+                .arg("-u")
+                .arg("origin")
+                .arg(head_ref.branch().unwrap())
+            )
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Cli::parse().into_command().and_then(|cmd| cmd.run())
+}

--- a/src/dah.rs
+++ b/src/dah.rs
@@ -1,0 +1,573 @@
+use chrono::{DateTime, FixedOffset};
+use git2::{Branch, Repository, Sort, Status, StatusOptions, StatusShow};
+use log::{info, warn};
+
+use crate::{
+    gittime::GitTime,
+    refname::{HeadRef, RemoteRef},
+};
+
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    None,
+    ResolveConflict,
+    CreateBranch,
+    RenameBranch,
+    StageChanges,
+    Commit,
+    Rebase {
+        head_ref: HeadRef,
+        upstream_ref: RemoteRef,
+    },
+    Push {
+        head_ref: HeadRef,
+        upstream_ref: Option<RemoteRef>,
+    },
+}
+
+/// Group of methods to collect repository state,
+/// for deciding the next action.
+pub trait Collector {
+    type Error;
+
+    /// name of default branch
+    fn default_branch(&self) -> Result<String, Self::Error>;
+    /// HEAD refname
+    fn head_ref(&self) -> Result<HeadRef, Self::Error>;
+    /// Refname of the remote tracking branch for HEAD if exists.
+    ///
+    /// It should be like `refs/remotes/origin/branch-name`
+    fn upstream_ref(&self) -> Result<Option<RemoteRef>, Self::Error>;
+    /// Check if the latest commit on HEAD and its remote tracking branch are same.
+    ///
+    /// For HEAD without remote tracking branch, should return `Ok(false)`.
+    fn is_synchronized(&self) -> Result<bool, Self::Error>;
+    /// Check if commits on the branch pointed by head_ref are at the top of
+    /// the remote tracking branch (upstream_ref). i.e., HEAD is already
+    /// rebased onto upstream_ref.
+    ///
+    /// For HEAD without remote tracking branch, should return `Ok(false)`.
+    fn is_based_on_remote(&self) -> Result<bool, Self::Error>;
+    /// Merged status of current index and work tree.
+    fn status(&self) -> Result<Status, Self::Error>;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RepositoryCollectorError {
+    #[error("commit inspection terminated")]
+    CommitInspectionTerminated,
+    #[error("{0}")]
+    InternalError(#[from] git2::Error),
+}
+
+pub struct RepositoryCollector<'a> {
+    repo: &'a Repository,
+    walk_limit: usize,
+}
+
+impl RepositoryCollector<'_> {
+    pub fn new(repo: &Repository) -> RepositoryCollector<'_> {
+        RepositoryCollector {
+            repo,
+            walk_limit: 100usize,
+        }
+    }
+
+    pub fn with_walk_limit(self, num_commits: usize) -> Self {
+        Self {
+            walk_limit: num_commits,
+            ..self
+        }
+    }
+}
+
+fn get_upstream_branch(
+    reference: git2::Reference<'_>,
+) -> Result<Option<Branch<'_>>, git2::Error> {
+    if reference.is_branch() {
+        match Branch::wrap(reference).upstream() {
+            Ok(upstream) => Ok(Some(upstream)),
+            Err(e) => {
+                if e.code() == git2::ErrorCode::NotFound {
+                    Ok(None)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+impl<'a> Collector for RepositoryCollector<'a> {
+    type Error = RepositoryCollectorError;
+
+    fn default_branch(&self) -> Result<String, Self::Error> {
+        Ok(self.repo.config()?.get_string("init.defaultbranch")?)
+    }
+
+    fn head_ref(&self) -> Result<HeadRef, Self::Error> {
+        Ok(HeadRef::new(self.repo.head()?.name().unwrap().to_owned()).unwrap())
+    }
+
+    fn upstream_ref(&self) -> Result<Option<RemoteRef>, Self::Error> {
+        let head = self.repo.head()?;
+        if let Some(upstream) = get_upstream_branch(head)? {
+            Ok(Some(
+                RemoteRef::new(upstream.into_reference().name().unwrap().to_owned()).unwrap(),
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn is_synchronized(&self) -> Result<bool, Self::Error> {
+        let head = self.repo.head()?;
+        let head_oid = head.peel_to_commit()?.id();
+        if let Some(upstream) = get_upstream_branch(head)? {
+            Ok(head_oid == upstream.into_reference().peel_to_commit()?.id())
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn is_based_on_remote(&self) -> Result<bool, Self::Error> {
+        let head = self.repo.head()?;
+        if let Some(upstream) = get_upstream_branch(head)? {
+            let upstream = upstream.into_reference();
+            let upstream_head = upstream.peel_to_commit()?.id();
+            let mut walk = self.repo.revwalk()?;
+
+            walk.push(self.repo.head()?.peel_to_commit()?.id())?;
+            walk.hide(upstream_head)?;
+            walk.set_sorting(Sort::TOPOLOGICAL)?;
+
+            info!(
+                "searching {}({}) from history of HEAD...",
+                upstream.name().unwrap_or_default(),
+                upstream_head
+            );
+
+            let mut count = self.walk_limit;
+            for oid in walk {
+                if count == 0 {
+                    return Err(RepositoryCollectorError::CommitInspectionTerminated);
+                }
+                let commit = self.repo.find_commit(oid?)?;
+                let time: GitTime = commit.time().into();
+                let time: DateTime<FixedOffset> = time.into();
+
+                info!(
+                    " * {} author={} time={}",
+                    commit.id(),
+                    commit.author(),
+                    time
+                );
+                if commit
+                    .parents()
+                    .map(|o| o.id())
+                    .any(|id| id == upstream_head)
+                {
+                    info!("DONE");
+                    return Ok(true);
+                }
+
+                count -= 1;
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn status(&self) -> Result<Status, Self::Error> {
+        let statuses = self.repo.statuses(Some(
+            StatusOptions::default().show(StatusShow::IndexAndWorkdir),
+        ))?;
+        // merge all statuses
+        Ok(statuses
+            .iter()
+            .map(|st| st.status())
+            .fold(Status::CURRENT, |a, b| a | b))
+    }
+}
+
+impl Action {
+    pub fn new<T>(collector: T) -> Result<Self, T::Error>
+    where
+        T: Collector,
+    {
+        let default_branch = collector.default_branch()?;
+        let head_ref = collector.head_ref()?;
+        let upstream_ref = collector.upstream_ref()?;
+        let status = collector.status()?;
+
+        let has_wt_change = status.is_wt_new()
+            || status.is_wt_modified()
+            || status.is_wt_deleted()
+            || status.is_wt_renamed()
+            || status.is_wt_typechange();
+        let has_index_change = status.is_index_new()
+            || status.is_index_modified()
+            || status.is_index_deleted()
+            || status.is_index_renamed()
+            || status.is_index_typechange();
+
+        if status.is_conflicted() {
+            return Ok(Self::ResolveConflict);
+        }
+        if has_wt_change {
+            return Ok(Self::StageChanges);
+        }
+        if has_index_change {
+            return Ok(Self::Commit);
+        }
+
+        if let Some(head_branch) = head_ref.branch() {
+            if collector.is_synchronized()? {
+                return Ok(Self::None);
+            }
+            if head_branch == default_branch {
+                info!("found local commits on default branch");
+                return Ok(Self::RenameBranch);
+            }
+
+            if let Some(upstream_ref) = upstream_ref {
+                if collector.is_based_on_remote()? {
+                    return Ok(Self::Push {
+                        head_ref,
+                        upstream_ref: Some(upstream_ref),
+                    });
+                }
+                return Ok(Self::Rebase {
+                    head_ref,
+                    upstream_ref,
+                });
+            } else {
+                return Ok(Self::Push {
+                    head_ref,
+                    upstream_ref: None,
+                });
+            }
+        }
+
+        // detached HEAD
+        Ok(Self::CreateBranch)
+    }
+}
+
+pub trait GitCli {
+    type Error;
+
+    fn status(&self) -> Result<(), Self::Error>;
+    fn create_branch_and_switch(&self) -> Result<(), Self::Error>;
+    fn rename_branch_and_switch(&self) -> Result<(), Self::Error>;
+    fn stage_changes(&self) -> Result<(), Self::Error>;
+    fn commit(&self) -> Result<(), Self::Error>;
+    fn pull_with_rebase(&self, upstream_ref: &str) -> Result<(), Self::Error>;
+    fn push(&self, head_ref: &str, upstream_ref: Option<&str>) -> Result<(), Self::Error>;
+}
+
+pub enum StepResult {
+    Abort { reason: &'static str },
+    Stop,
+    Continue,
+}
+
+pub fn step<G>(action: Action, cli: &G) -> Result<StepResult, G::Error>
+where
+    G: GitCli,
+{
+    match action {
+        Action::None => {
+            info!("it's alright. happy hacking!");
+            Ok(StepResult::Stop)
+        }
+        Action::ResolveConflict => {
+            warn!("resolve conflict first.");
+            cli.status()?;
+            Ok(StepResult::Stop)
+        }
+        Action::CreateBranch => {
+            cli.create_branch_and_switch()?;
+            Ok(StepResult::Continue)
+        }
+        Action::RenameBranch => {
+            info!("cleaning local changes on default branch by renaming it");
+            cli.rename_branch_and_switch()?;
+            Ok(StepResult::Continue)
+        }
+        Action::StageChanges => {
+            info!("there are unstaged changes");
+            cli.stage_changes()?;
+            Ok(StepResult::Continue)
+        }
+        Action::Commit => {
+            info!("there are staged changes");
+            cli.commit()?;
+            Ok(StepResult::Continue)
+        }
+        Action::Rebase { upstream_ref, .. } => {
+            cli.pull_with_rebase(upstream_ref.as_str())?;
+            Ok(StepResult::Continue)
+        }
+        Action::Push {
+            head_ref,
+            upstream_ref,
+        } => {
+            let upstream_ref = upstream_ref.as_ref().map(|o| o.as_str());
+            cli.push(head_ref.as_str(), upstream_ref)?;
+            Ok(StepResult::Stop)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use git2::{Status};
+
+    use crate::refname::{HeadRef, RemoteRef};
+
+    use super::{Action, Collector};
+
+    #[derive(Debug, Clone, Default)]
+    struct MockState {
+        default_branch: Option<String>,
+        head_ref: Option<HeadRef>,
+        upstream: Option<Option<(RemoteRef, bool, bool)>>,
+        status: Option<Status>,
+    }
+
+    impl MockState {
+        fn with_default_branch(self, branch: &str) -> Self {
+            Self {
+                default_branch: Some(branch.to_owned()),
+                ..self
+            }
+        }
+
+        fn with_head_ref(self, head_ref: &str) -> Self {
+            Self {
+                head_ref: Some(HeadRef::new(head_ref).unwrap()),
+                ..self
+            }
+        }
+
+        fn with_detached_head(self) -> Self {
+            Self {
+                head_ref: Some(HeadRef::detached()),
+                ..self
+            }
+        }
+
+        fn with_upstream_ref(
+            self,
+            upstream_ref: &str,
+            is_synchronized: bool,
+            is_based_on_remote: bool,
+        ) -> Self {
+            Self {
+                upstream: Some(Some((
+                    RemoteRef::new(upstream_ref).unwrap(),
+                    is_synchronized,
+                    is_based_on_remote,
+                ))),
+                ..self
+            }
+        }
+
+        fn with_no_upstream(self) -> Self {
+            Self {
+                upstream: Some(None),
+                ..self
+            }
+        }
+
+        fn with_status(self, status: Status) -> Self {
+            Self {
+                status: Some(status),
+                ..self
+            }
+        }
+    }
+
+    impl Collector for MockState {
+        type Error = &'static str;
+
+        fn default_branch(&self) -> Result<String, Self::Error> {
+            if let Some(o) = &self.default_branch {
+                Ok(o.clone())
+            } else {
+                Err("default_branch unset")
+            }
+        }
+
+        fn head_ref(&self) -> Result<HeadRef, Self::Error> {
+            if let Some(o) = &self.head_ref {
+                Ok(o.clone())
+            } else {
+                Err("head_ref unset")
+            }
+        }
+
+        fn upstream_ref(&self) -> Result<Option<RemoteRef>, Self::Error> {
+            if let Some(upstream) = &self.upstream {
+                if let Some((o, _, _)) = upstream {
+                    Ok(Some(o.clone()))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Err("upstream_ref unset")
+            }
+        }
+
+        fn is_synchronized(&self) -> Result<bool, Self::Error> {
+            if let Some(upstream) = &self.upstream {
+                if let Some((_, o, _)) = upstream {
+                    Ok(*o)
+                } else {
+                    Ok(false)
+                }
+            } else {
+                Ok(false)
+            }
+        }
+
+        fn is_based_on_remote(&self) -> Result<bool, Self::Error> {
+            if let Some(upstream) = &self.upstream {
+                if let Some((_, _, o)) = upstream {
+                    Ok(*o)
+                } else {
+                    Ok(false)
+                }
+            } else {
+                Ok(false)
+            }
+        }
+
+        fn status(&self) -> Result<Status, Self::Error> {
+            if let Some(o) = self.status {
+                Ok(o)
+            } else {
+                Err("status unset")
+            }
+        }
+    }
+
+    #[test]
+    fn test_action_from() {
+        let cases = [
+            // index or wt has conflict -> should resolve conflict
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", true, true)
+                    .with_status(Status::CONFLICTED),
+                Action::ResolveConflict,
+            ),
+            // on default branch and synchronized -> nothing to do.
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/main")
+                    .with_upstream_ref("refs/remotes/origin/main", true, true)
+                    .with_status(Status::CURRENT),
+                Action::None,
+            ),
+            // on default branch with local changes -> should rename the branch
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/main")
+                    .with_upstream_ref("refs/remotes/origin/main", false, true)
+                    .with_status(Status::CURRENT),
+                Action::RenameBranch,
+            ),
+            // on detached head -> should create branch
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_detached_head()
+                    .with_no_upstream()
+                    .with_status(Status::CURRENT),
+                Action::CreateBranch,
+            ),
+            // on topic branch and no remote tracking branch -> push
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_no_upstream()
+                    .with_status(Status::CURRENT),
+                Action::Push {
+                    head_ref: HeadRef::new("refs/heads/foo").unwrap(),
+                    upstream_ref: None,
+                },
+            ),
+            // on topic branch and include remote commits -> push
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", false, true)
+                    .with_status(Status::CURRENT),
+                Action::Push {
+                    head_ref: HeadRef::new("refs/heads/foo").unwrap(),
+                    upstream_ref: Some(RemoteRef::new("refs/remotes/origin/foo").unwrap()),
+                },
+            ),
+            // on topic branch, but it doesn't include remote commits -> rebase
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", false, false)
+                    .with_status(Status::CURRENT),
+                Action::Rebase {
+                    head_ref: HeadRef::new("refs/heads/foo").unwrap(),
+                    upstream_ref: RemoteRef::new("refs/remotes/origin/foo").unwrap(),
+                },
+            ),
+            // on topic branch and dirty -> stage changes
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", true, true)
+                    .with_status(Status::WT_MODIFIED),
+                Action::StageChanges,
+            ),
+            // on topic branch and staged -> commit
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", true, true)
+                    .with_status(Status::INDEX_NEW),
+                Action::Commit,
+            ),
+            // on topic branch and synchronized -> nothing to do
+            (
+                MockState::default()
+                    .with_default_branch("main")
+                    .with_head_ref("refs/heads/foo")
+                    .with_upstream_ref("refs/remotes/origin/foo", true, true)
+                    .with_status(Status::CURRENT),
+                Action::None,
+            ),
+        ];
+
+        for (i, (given, expected)) in cases.into_iter().enumerate() {
+            match Action::new(given.clone()) {
+                Ok(s) => assert_eq!(
+                    expected, s,
+                    "#{}: from {:?}, expected {:?} but got {:?}",
+                    i, given, expected, s
+                ),
+                e => unreachable!("#{}: from {:?}, expected Ok but got {:?}", i, given, e),
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod dah;
 pub mod git2_consts;
 pub mod github;
 pub mod gittime;
 pub mod pathname;
+pub mod refname;
 pub mod reltime;

--- a/src/refname.rs
+++ b/src/refname.rs
@@ -1,0 +1,178 @@
+#[derive(Debug, PartialEq, Clone)]
+enum HeadRefImpl {
+    Branch { full: String },
+    Detached,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct HeadRef(HeadRefImpl);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct RemoteRef {
+    full: String,
+    remote_len: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RefnameError {
+    #[error("head ref name should be like refs/heads/BRANCH or just HEAD, but got {refname}")]
+    InvalidHeadRefFormat { refname: String },
+    #[error("remote ref name should be like refs/remotes/REMOTE/BRANCH, but got {refname}")]
+    InvalidRemoteRefFormat { refname: String },
+}
+
+impl HeadRef {
+    pub fn new<S: Into<String>>(refname: S) -> Result<HeadRef, RefnameError> {
+        HeadRefImpl::new(refname).map(HeadRef)
+    }
+
+    pub fn detached() -> HeadRef {
+        HeadRef(HeadRefImpl::Detached)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_string(self) -> String {
+        self.0.into_string()
+    }
+
+    pub fn branch(&self) -> Option<&str> {
+        self.0.branch()
+    }
+}
+
+impl HeadRefImpl {
+    const PREFIX: &'static str = "refs/heads/";
+    const HEAD: &'static str = "HEAD";
+
+    fn new<S: Into<String>>(refname: S) -> Result<HeadRefImpl, RefnameError> {
+        let refname: String = refname.into();
+        if refname.strip_prefix(Self::PREFIX).is_some() {
+            Ok(HeadRefImpl::Branch { full: refname })
+        } else if refname == Self::HEAD {
+            Ok(HeadRefImpl::Detached)
+        } else {
+            Err(RefnameError::InvalidHeadRefFormat { refname })
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            HeadRefImpl::Branch { full, .. } => full,
+            HeadRefImpl::Detached => Self::HEAD,
+        }
+    }
+
+    fn into_string(self) -> String {
+        match self {
+            HeadRefImpl::Branch { full } => full,
+            HeadRefImpl::Detached => Self::HEAD.to_owned(),
+        }
+    }
+
+    fn branch(&self) -> Option<&str> {
+        match self {
+            HeadRefImpl::Branch { full } => Some(&full[Self::PREFIX.len()..]),
+            HeadRefImpl::Detached => None,
+        }
+    }
+}
+
+impl RemoteRef {
+    const PREFIX: &'static str = "refs/remotes/";
+
+    pub fn new<S: Into<String>>(refname: S) -> Result<RemoteRef, RefnameError> {
+        let refname: String = refname.into();
+        if let Some(remote_and_branch) = refname.strip_prefix(Self::PREFIX) {
+            if let Some((remote, _branch)) = remote_and_branch.split_once('/') {
+                let remote_len = remote.len();
+                return Ok(RemoteRef {
+                    full: refname,
+                    remote_len,
+                });
+            }
+        }
+
+        Err(RefnameError::InvalidRemoteRefFormat {
+            refname: refname.to_owned(),
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.full.as_str()
+    }
+
+    pub fn remote(&self) -> &str {
+        let i = Self::PREFIX.len();
+        let j = i + self.remote_len;
+        &self.full[i..j]
+    }
+
+    pub fn branch(&self) -> &str {
+        let i = Self::PREFIX.len() + self.remote_len + "/".len();
+        &self.full[i..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::refname::HeadRef;
+
+    use super::RemoteRef;
+
+    #[test]
+    fn test_valid_head_ref() {
+        let cases = [
+            ("refs/heads/foo", Some("foo")),
+            ("refs/heads/foo/bar", Some("foo/bar")),
+            ("HEAD", None),
+        ];
+
+        for (given, want_branch) in cases {
+            let got = HeadRef::new(given);
+            assert!(got.is_ok_and(|r| r.as_str() == given && r.branch() == want_branch));
+        }
+    }
+
+    #[test]
+    fn test_invalid_head_ref() {
+        let cases = ["foo", "foo/bar", "refs/tags/v0", "refs/remotes/origin/foo"];
+
+        for given in cases {
+            let got = HeadRef::new(given);
+            assert!(got.is_err())
+        }
+    }
+
+    #[test]
+    fn test_valid_remote_ref() {
+        let cases = [
+            ("refs/remotes/origin/foo", "origin", "foo"),
+            ("refs/remotes/origin/foo/bar", "origin", "foo/bar"),
+        ];
+
+        for (given, want_remote, want_branch) in cases {
+            let got = RemoteRef::new(given);
+            assert!(got.is_ok_and(|r| r.as_str() == given
+                && r.remote() == want_remote
+                && r.branch() == want_branch));
+        }
+    }
+
+    #[test]
+    fn test_invalid_remote_ref() {
+        let cases = [
+            "foo",
+            "foo/bar",
+            "refs/heads/foo/bar",
+            "refs/remotes/origin",
+        ];
+
+        for given in cases {
+            let got = RemoteRef::new(given);
+            assert!(got.is_err())
+        }
+    }
+}


### PR DESCRIPTION
Add git-dah command. It will:

* stage changes by `git add -u` when you have dirty work tree
* commit changes when you have change in index
* rename current branch to new one, when you are on a default branch
  with local changes
* create new branch and switch into it, when you are on a detached head
* rebase onto the remote tracking branch so history will be fast-
  forwardable when you are on a branch diverged from remote
* do `git push --force-with-lease --force-if-includes` when you are on a
  branch which is on a top of the remote tracking branch