### PR TITLE
feat(git-dah): add protected branch config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fnmatch-sys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2669e8526f74ef00ccd2011b1e357f6eebcea2925b28e67fcedd1740196f45b3"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +257,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fnmatch-sys",
  "git2",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.20.2"
 regex = "1.11.1"
 thiserror = "2.0.3"
 ulid = "1.1.3"
+fnmatch-sys = "1.0.0"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/bin/dah.rs
+++ b/bin/dah.rs
@@ -1,6 +1,10 @@
-use std::{ffi::OsString, io::{self}, process::Stdio};
+use std::{
+    ffi::OsString,
+    io::{self},
+    process::Stdio,
+};
 
-use clap::{Parser};
+use clap::Parser;
 use git2::Repository;
 use git_toolbox::{
     dah::{self, Action, GitCli, RepositoryCollector, StepResult},
@@ -15,12 +19,12 @@ enum DahError {
     #[error("{command:?} failed with exit code {code:?}")]
     ExitStatus {
         command: OsString,
-        code: Option<i32>
+        code: Option<i32>,
     },
     #[error("internal error: {0}")]
     IO(#[from] io::Error),
     #[error("internal error: {0}")]
-    Git(#[from] git2::Error)
+    Git(#[from] git2::Error),
 }
 
 #[derive(Parser)]
@@ -134,55 +138,50 @@ impl Command {
     }
 }
 
-
 impl GitCli for Command {
     type Error = DahError;
 
     fn status(&self) -> Result<(), Self::Error> {
-        self.run_command(std::process::Command::new("git")
-            .arg("status")
-        )
+        self.run_command(std::process::Command::new("git").arg("status"))
     }
 
     fn create_branch_and_switch(&self) -> Result<(), Self::Error> {
         let branch_name = self.generate_branch_name()?;
-        self.run_command(std::process::Command::new("git")
-            .arg("switch")
-            .arg("-c")
-            .arg(branch_name)
+        self.run_command(
+            std::process::Command::new("git")
+                .arg("switch")
+                .arg("-c")
+                .arg(branch_name),
         )
     }
 
     fn rename_branch_and_switch(&self) -> Result<(), Self::Error> {
         let branch_name = self.generate_branch_name()?;
-        self.run_command(std::process::Command::new("git")
-            .arg("branch")
-            .arg("-m")
-            .arg(branch_name)
+        self.run_command(
+            std::process::Command::new("git")
+                .arg("branch")
+                .arg("-m")
+                .arg(branch_name),
         )
     }
 
     fn stage_changes(&self) -> Result<(), Self::Error> {
-        self.run_command(std::process::Command::new("git")
-            .arg("add")
-            .arg("-u")
-        )
+        self.run_command(std::process::Command::new("git").arg("add").arg("-u"))
     }
 
     fn commit(&self) -> Result<(), Self::Error> {
-        self.run_command(std::process::Command::new("git")
-            .arg("commit")
-        )
+        self.run_command(std::process::Command::new("git").arg("commit"))
     }
 
     fn pull_with_rebase(&self, upstream_ref: &str) -> Result<(), Self::Error> {
         // TODO: receive RemoteRef
         let upstream_ref = RemoteRef::new(upstream_ref).unwrap();
-        self.run_command(std::process::Command::new("git")
-            .arg("pull")
-            .arg("--rebase")
-            .arg(upstream_ref.remote())
-            .arg(upstream_ref.branch())
+        self.run_command(
+            std::process::Command::new("git")
+                .arg("pull")
+                .arg("--rebase")
+                .arg(upstream_ref.remote())
+                .arg(upstream_ref.branch()),
         )
     }
 
@@ -190,22 +189,24 @@ impl GitCli for Command {
         let head_ref = HeadRef::new(head_ref).unwrap();
         if let Some(upstream_ref) = upstream_ref {
             let upstream_ref = RemoteRef::new(upstream_ref).unwrap();
-            self.run_command(std::process::Command::new("git")
-                .arg("push")
-                .arg("--force-with-lease")
-                .arg("--force-if-includes")
-                .arg("-u")
-                .arg(upstream_ref.remote())
-                .arg(head_ref.branch().unwrap())
+            self.run_command(
+                std::process::Command::new("git")
+                    .arg("push")
+                    .arg("--force-with-lease")
+                    .arg("--force-if-includes")
+                    .arg("-u")
+                    .arg(upstream_ref.remote())
+                    .arg(head_ref.branch().unwrap()),
             )
         } else {
-            self.run_command(std::process::Command::new("git")
-                .arg("push")
-                .arg("--force-with-lease")
-                .arg("--force-if-includes")
-                .arg("-u")
-                .arg("origin")
-                .arg(head_ref.branch().unwrap())
+            self.run_command(
+                std::process::Command::new("git")
+                    .arg("push")
+                    .arg("--force-with-lease")
+                    .arg("--force-if-includes")
+                    .arg("-u")
+                    .arg("origin")
+                    .arg(head_ref.branch().unwrap()),
             )
         }
     }

--- a/src/dah.rs
+++ b/src/dah.rs
@@ -1,11 +1,10 @@
 use std::{
-    ffi::{CStr, CString, OsStr},
-    os::unix::ffi::OsStrExt,
+    ffi::{CStr, CString},
 };
 
 use chrono::{DateTime, FixedOffset};
-use fnmatch_sys::{self, FNM_NOESCAPE, FNM_PATHNAME};
-use git2::{Branch, Refspec, Refspecs, Repository, Sort, Status, StatusOptions, StatusShow};
+use fnmatch_sys::{self, FNM_NOESCAPE};
+use git2::{Branch, Repository, Sort, Status, StatusOptions, StatusShow};
 use log::{info, warn};
 
 use crate::{
@@ -135,7 +134,7 @@ impl<'a> Collector for RepositoryCollector<'a> {
             let config_protected = config.get_str("dah.protectedbranch")?;
             if !config_protected.is_empty() {
                 let branch_c_string = CString::new(branch).unwrap();
-                let is_match = config_protected.split(':').into_iter().any(|n| {
+                let is_match = config_protected.split(':').any(|n| {
                     let pat = CString::new(n).unwrap();
                     fnmatch(pat.as_c_str(), branch_c_string.as_c_str())
                 });

--- a/src/dah.rs
+++ b/src/dah.rs
@@ -1,5 +1,11 @@
+use std::{
+    ffi::{CStr, CString, OsStr},
+    os::unix::ffi::OsStrExt,
+};
+
 use chrono::{DateTime, FixedOffset};
-use git2::{Branch, Repository, Sort, Status, StatusOptions, StatusShow};
+use fnmatch_sys::{self, FNM_NOESCAPE, FNM_PATHNAME};
+use git2::{Branch, Refspec, Refspecs, Repository, Sort, Status, StatusOptions, StatusShow};
 use log::{info, warn};
 
 use crate::{
@@ -32,6 +38,10 @@ pub trait Collector {
 
     /// name of default branch
     fn default_branch(&self) -> Result<String, Self::Error>;
+
+    /// check if the HEAD is protected
+    fn is_head_protected(&self) -> Result<bool, Self::Error>;
+
     /// HEAD refname
     fn head_ref(&self) -> Result<HeadRef, Self::Error>;
     /// Refname of the remote tracking branch for HEAD if exists.
@@ -81,9 +91,7 @@ impl RepositoryCollector<'_> {
     }
 }
 
-fn get_upstream_branch(
-    reference: git2::Reference<'_>,
-) -> Result<Option<Branch<'_>>, git2::Error> {
+fn get_upstream_branch(reference: git2::Reference<'_>) -> Result<Option<Branch<'_>>, git2::Error> {
     if reference.is_branch() {
         match Branch::wrap(reference).upstream() {
             Ok(upstream) => Ok(Some(upstream)),
@@ -100,11 +108,44 @@ fn get_upstream_branch(
     }
 }
 
+fn fnmatch(pat: &CStr, s: &CStr) -> bool {
+    let pat = pat.as_ptr();
+    let s = s.as_ptr();
+
+    unsafe { fnmatch_sys::fnmatch(pat, s, FNM_NOESCAPE) == 0 }
+}
+
 impl<'a> Collector for RepositoryCollector<'a> {
     type Error = RepositoryCollectorError;
 
     fn default_branch(&self) -> Result<String, Self::Error> {
         Ok(self.repo.config()?.get_string("init.defaultbranch")?)
+    }
+
+    fn is_head_protected(&self) -> Result<bool, Self::Error> {
+        let head_ref = HeadRef::new(self.repo.head()?.name().unwrap().to_owned()).unwrap();
+
+        if let Some(branch) = head_ref.branch() {
+            let config = self.repo.config()?;
+            let default_branch = config.get_str("init.defaultbranch")?;
+            if branch == default_branch {
+                return Ok(true);
+            }
+
+            let config_protected = config.get_str("dah.protectedbranch")?;
+            if !config_protected.is_empty() {
+                let branch_c_string = CString::new(branch).unwrap();
+                let is_match = config_protected.split(':').into_iter().any(|n| {
+                    let pat = CString::new(n).unwrap();
+                    fnmatch(pat.as_c_str(), branch_c_string.as_c_str())
+                });
+                if is_match {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
     }
 
     fn head_ref(&self) -> Result<HeadRef, Self::Error> {
@@ -324,11 +365,22 @@ where
 
 #[cfg(test)]
 mod tests {
-    use git2::{Status};
+    use git2::Status;
 
     use crate::refname::{HeadRef, RemoteRef};
 
     use super::{Action, Collector};
+
+    use super::fnmatch;
+
+    #[test]
+    fn test_fnmatch() {
+        let cases = [(c"foo/*", c"foo/bar/baz")];
+
+        for (pat, s) in cases {
+            assert!(fnmatch(pat, s))
+        }
+    }
 
     #[derive(Debug, Clone, Default)]
     struct MockState {
@@ -400,6 +452,10 @@ mod tests {
             } else {
                 Err("default_branch unset")
             }
+        }
+
+        fn is_head_protected(&self) -> Result<bool, Self::Error> {
+            todo!()
         }
 
         fn head_ref(&self) -> Result<HeadRef, Self::Error> {


### PR DESCRIPTION
git-dah now recognizes `dah.protectedbranch` git-config value, which is a pattern strings separated by `:`.
git-dah no longer push against the remote branches matching to the patterns. The pattern will be tested against branch name by fnmatch(3) without escaping characters (i.e. `FNM_NOESCAPE`).

To protect `develop`, `release` and branch names start with `release/`, configure with following command:

```sh
git config dah.protectedbranch 'develop:release:release/*'
```