### PR TITLE
feat(git-dah): add --cooperative option

### DIFF
--- a/bin/dah.rs
+++ b/bin/dah.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use git2::Repository;
 use git_toolbox::app::dah::Application;
 
@@ -18,6 +18,13 @@ struct Cli {
         default_value = "100"
     )]
     limit: usize,
+    #[arg(
+        long = "cooperative",
+        visible_alias = "no-force",
+        help = "Extra safety for team programming; meaning always rebase HEAD onto the remote branch and don't push with force",
+        action = ArgAction::SetFalse,
+    )]
+    allow_force_push: bool,
 }
 
 impl Cli {
@@ -25,7 +32,8 @@ impl Cli {
         let repo = Repository::open_from_env()?;
         let app = Application::new(repo)
             .with_step(self.step)
-            .with_limit(self.limit);
+            .with_limit(self.limit)
+            .with_allow_force_push(self.allow_force_push);
         Ok(app)
     }
 }


### PR DESCRIPTION
Allow users to opt-out `--force-with-lease` and `--force-if-includes` options from git-push command automatically invoked by git-dah. So this is weak "Fus" shout to the full version "Fus Ro Dah".
Thinking about doing mob programming remotely, this gives extra safety in case that multiple developers busy-pushing the same branch.

Additionally, git-dah now checks HEAD reflog when deciding to do `pull --rebase`; which means `pull` will be skipped if the ref on the top of remote tracking branch is included in reflog in current branch.
Merge is no longer triggered when you just amended the commit.
With `--cooperative` option, this behavior will be disabled.