### PR TITLE
chore(*): allow selective build of binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,17 @@ license = "MIT OR Apache-2.0"
 [[bin]]
 name = "git-dah"
 path = "bin/dah.rs"
+required-features = ["git-dah"]
 
 [[bin]]
 name = "git-stale"
 path = "bin/stale.rs"
+required-features = ["git-stale"]
 
 [[bin]]
 name = "git-whose"
 path = "bin/whose.rs"
+required-features = ["git-whose"]
 
 [profile.release]
 strip = true
@@ -36,3 +39,9 @@ fnmatch-sys = "1.0.0"
 [dev-dependencies]
 tempfile = "3.14.0"
 url = "2.5.4"
+
+[features]
+default = ["git-dah", "git-stale", "git-whose"]
+git-dah = []
+git-stale = []
+git-whose = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # git-toolbox: shorthands for git operation
 
+git-toolbox is a collection of commands work with [git](https://git-scm.com/).
+
+* [git-dah](#git-dah) / a push command knows what you want
+* [git-stale](#git-stale) / lists stale branches
+* [git-whose](#git-whose) / find codeowners
+
 ## Installation
 
 If you have `cargo`, run following command:
@@ -8,7 +14,13 @@ If you have `cargo`, run following command:
 cargo install --git https://github.com/oakcask/git-toolbox.git
 ```
 
-Or, download pre-built binary:
+Maybe you only want one of the commands git-toolbox provides:
+
+```
+cargo install --git https://github.com/oakcask/git-toolbox.git --no-default-features --features git-stale
+```
+
+Or, download pre-built binaries:
 
 ### Linux x86-64
 


### PR DESCRIPTION
git-toolbox crate now has feature flags for each binaries the crate provides, to enable us to selective installation:

```
cargo install --git https://github.com/oakcask/git-toolbox.git --no-default-features --features git-stale
```