### PR TITLE
feat(git-dah): fetch first

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Options:
   -1, --step           Do stepwise execution
       --limit <LIMIT>  Increase number of commits to scan in history [default: 100]
       --cooperative    Extra safety for team programming; meaning always rebase HEAD onto the remote branch and don't push with force [aliases: no-force]
+      --no-fetch       Do not invoke git-fetch automatically
   -h, --help           Print help
 ```
 

--- a/bin/dah.rs
+++ b/bin/dah.rs
@@ -25,6 +25,12 @@ struct Cli {
         action = ArgAction::SetFalse,
     )]
     allow_force_push: bool,
+    #[arg(
+        long = "no-fetch",
+        help = "Do not invoke git-fetch automatically",
+        action = ArgAction::SetFalse,
+    )]
+    fetch_first: bool,
 }
 
 impl Cli {
@@ -33,7 +39,8 @@ impl Cli {
         let app = Application::new(repo)
             .with_step(self.step)
             .with_limit(self.limit)
-            .with_allow_force_push(self.allow_force_push);
+            .with_allow_force_push(self.allow_force_push)
+            .with_fetch_first(self.fetch_first);
         Ok(app)
     }
 }

--- a/src/app/dah.rs
+++ b/src/app/dah.rs
@@ -218,6 +218,7 @@ pub struct Application {
     step: bool,
     limit: usize,
     allow_force_push: bool,
+    fetch_first: bool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -249,6 +250,7 @@ impl Application {
             step: false,
             limit: 100,
             allow_force_push: true,
+            fetch_first: true,
         }
     }
 
@@ -267,8 +269,21 @@ impl Application {
         }
     }
 
+    pub fn with_fetch_first(self, fetch_first: bool) -> Self {
+        Self {
+            fetch_first,
+            ..self
+        }
+    }
+
     pub fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         env_logger::init();
+
+        if self.fetch_first {
+            if let Err(e) = self.run_command(std::process::Command::new("git").arg("fetch")) {
+                error!("fetch failed: {:?}; but we'll continue.", e);
+            }
+        }
 
         loop {
             let action = Action::new(&self)?;


### PR DESCRIPTION
git-dah now do git-fetch at first.
In addition allows users to skip this behavior by using `--no-fetch` option, because this is time-consuming action.