### PR TITLE
feat(git-dah): consider remote's default branch

### DIFF
--- a/src/app/dah.rs
+++ b/src/app/dah.rs
@@ -74,7 +74,9 @@ impl Collector for Application {
                 let mut cb = git2::RemoteCallbacks::new();
                 let config = self.repo.config()?;
                 let mut cred_cb = CredentialCallback::new(config);
-                cb.credentials(move |url, username, allowed_types| cred_cb.try_next(url, username, allowed_types));
+                cb.credentials(move |url, username, allowed_types| {
+                    cred_cb.try_next(url, username, allowed_types)
+                });
                 remote.connect_auth(git2::Direction::Fetch, Some(cb), None)?;
 
                 if let Ok(remote_default_branch) = remote.default_branch() {
@@ -82,7 +84,7 @@ impl Collector for Application {
                         let remote_default_branch = HeadRef::new(remote_default_branch).unwrap();
                         let remote_default_branch = remote_default_branch.branch().unwrap();
                         if branch == remote_default_branch {
-                            return Ok(true)
+                            return Ok(true);
                         }
                     }
                 }
@@ -611,14 +613,7 @@ mod tests {
         let tree = origin.treebuilder(None)?;
         let tree = tree.write()?;
         let tree = origin.find_tree(tree)?;
-        origin.commit(
-            Some("refs/heads/main"),
-            &author,
-            &author,
-            "c1",
-            &tree,
-            &[],
-        )?;
+        origin.commit(Some("refs/heads/main"), &author, &author, "c1", &tree, &[])?;
         origin.set_head("refs/heads/main")?;
 
         let origin_path = origin_path.to_str().unwrap();
@@ -634,7 +629,10 @@ mod tests {
             local.set_head("refs/heads/main")?;
         }
 
-        assert!(Application::new(local).is_remote_head()?, "expected local's HEAD is remote HEAD");
+        assert!(
+            Application::new(local).is_remote_head()?,
+            "expected local's HEAD is remote HEAD"
+        );
 
         Ok(())
     }

--- a/src/app/dah.rs
+++ b/src/app/dah.rs
@@ -5,7 +5,7 @@ use crate::git::{GitTime, HeadRef, RemoteRef};
 use chrono::{DateTime, FixedOffset};
 use fnmatch_sys::{self, FNM_NOESCAPE};
 use git2::{Branch, ErrorCode, Repository, Sort, Status, StatusOptions, StatusShow};
-use log::{debug, error, info, warn};
+use log::{error, info, warn};
 use regex::Regex;
 use statemachine::StepResult;
 use statemachine::{Action, Collector, Dispatcher};
@@ -69,7 +69,7 @@ impl Collector for Application {
         let head_ref = HeadRef::new(self.repo.head()?.name().unwrap().to_owned()).unwrap();
 
         if let Some(branch) = head_ref.branch() {
-            for remote in self.repo.remotes()?.into_iter().filter_map(|o| o) {
+            for remote in self.repo.remotes()?.into_iter().flatten() {
                 let mut remote = self.repo.find_remote(remote)?;
                 let mut cb = git2::RemoteCallbacks::new();
                 let config = self.repo.config()?;

--- a/src/app/dah/statemachine.rs
+++ b/src/app/dah/statemachine.rs
@@ -286,7 +286,7 @@ mod tests {
                 if let Some(upstream) = &self.upstream {
                     if let Some((o, _, _, is_head)) = upstream {
                         if branch == o.branch() && *is_head {
-                            return Ok(true)
+                            return Ok(true);
                         }
                     }
                 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,3 +5,4 @@ mod refname;
 pub use consts::IndexStage;
 pub use gittime::GitTime;
 pub use refname::{HeadRef, RefnameError, RemoteRef};
+pub mod credentials;

--- a/src/git/credentials.rs
+++ b/src/git/credentials.rs
@@ -1,0 +1,87 @@
+use std::{fs::File, path::{Path, PathBuf}};
+
+use git2::{Cred};
+use log::{info, warn};
+
+#[derive(Default)]
+struct SshState {
+    id_candidates: Vec<&'static str>,
+}
+
+enum Method {
+    Unavailable,
+    SshAgent,
+    SshId(SshState),
+    Helper,
+    Default
+}
+
+pub struct CredentialCallback {
+    config: git2::Config,
+    next_method: Option<Method>,
+}
+
+impl CredentialCallback {
+    pub fn new(config: git2::Config) -> Self {
+        CredentialCallback { config, next_method: None }
+    }
+
+    pub fn try_next(&mut self, url: &str, username: Option<&str>, allowed_types: git2::CredentialType) -> Result<Cred, git2::Error> {
+        match self.next_method.as_mut() {
+            Some(Method::Helper) => {
+                self.next_method = Some(Method::Unavailable); // never retry if the helper fails.
+                info!("trying credential helper");
+                Cred::credential_helper(&self.config, url, username)
+            }
+            Some(Method::SshAgent) => {
+                self.next_method = Some(Method::SshId(SshState { id_candidates: vec![
+                    "id_ecdsa",
+                    "id_ecdsa-sk",
+                    "id_ed25519",
+                    "id_ed25519-sk",
+                ]}));
+                Cred::ssh_key_from_agent(username.unwrap_or("git"))
+            }
+            Some(Method::SshId(state)) => {
+                if let Some(key) = state.id_candidates.pop() {
+                    let mut path = PathBuf::from(std::env::var("HOME").unwrap());
+                    path.push(".ssh");
+                    path.push(key);
+                    let path = path.as_path();
+                    info!("trying ssh key {path:?}");
+                    if let Err(_) = File::open(path) {
+                        self.try_next(url, username, allowed_types)
+                    } else {
+                        Cred::ssh_key(username.unwrap_or("git"), None, path, None)                       
+                    }
+                } else {
+                    Err(git2::Error::from_str("no valid credentials available"))
+                }
+            }
+            Some(Method::Default) => {
+                self.next_method = Some(Method::Unavailable); // never retry if the default fails.
+                info!("trying default credential");
+                Cred::default()
+            }
+            Some(Method::Unavailable) => {
+                Err(git2::Error::from_str("no valid credentials available"))
+            }
+            None => {
+                self.next_method = Some(Self::choose_method(allowed_types));
+                self.try_next(url, username, allowed_types)
+            }
+        }
+    }
+
+    fn choose_method(allowed_types: git2::CredentialType) -> Method {
+        if allowed_types.is_user_pass_plaintext() {
+            Method::Helper
+        } else if allowed_types.is_default() {
+            Method::Default
+        } else if allowed_types.is_ssh_key() {
+            Method::SshAgent
+        } else {
+            Method::Unavailable
+        }
+    }
+}

--- a/src/git/credentials.rs
+++ b/src/git/credentials.rs
@@ -54,7 +54,7 @@ impl CredentialCallback {
                     path.push(key);
                     let path = path.as_path();
                     info!("trying ssh key {path:?}");
-                    if let Err(_) = File::open(path) {
+                    if File::open(path).is_err() {
                         self.try_next(url, username, allowed_types)
                     } else {
                         Cred::ssh_key(username.unwrap_or("git"), None, path, None)

--- a/src/git/credentials.rs
+++ b/src/git/credentials.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::File,
-    path::PathBuf,
-};
+use std::{fs::File, path::PathBuf};
 
 use git2::Cred;
 use log::info;

--- a/src/git/credentials.rs
+++ b/src/git/credentials.rs
@@ -1,10 +1,10 @@
 use std::{
     fs::File,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use git2::Cred;
-use log::{info, warn};
+use log::info;
 
 #[derive(Default)]
 struct SshState {


### PR DESCRIPTION
closes #288

git-dah now never push remote's default branch.

Previous version of git-dah guesses the "protected" branch name by cheking only `init.defaultbranch` and `dah.protectedbranch`. Now it consideres remote's default branches.