### PR TITLE
chore: use ubuntu-24.04-arm runner for ARM64 build

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -42,9 +42,9 @@ jobs:
             - os: ubuntu-latest
               target: x86_64-unknown-linux-gnu
               cross: false
-            - os: ubuntu-latest
+            - os: ubuntu-24.04-arm
               target: aarch64-unknown-linux-gnu
-              cross: true
+              cross: false
             - os: macos-latest
               target: aarch64-apple-darwin
               cross: false


### PR DESCRIPTION
use ubuntu-24.04-arm runner for ARM64 build to disable `cross`