### PR TITLE
fix: release binaries (release workflow fixed)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -84,6 +84,7 @@ jobs:
       - build
     if: needs.release-please.outputs.releases_created == 'true'
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist


### PR DESCRIPTION
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```