### PR TITLE
test(git-whose): missing `CARGO_BIN_EXE_git-whose`

### DIFF
--- a/tests/common/bin.rs
+++ b/tests/common/bin.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+static GIT_WHOSE_BIN: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+
+pub fn git_whose_exe() -> PathBuf {
+    GIT_WHOSE_BIN
+        .get_or_init(resolve_git_whose_exe)
+        .as_ref()
+        .unwrap_or_else(|err| panic!("{err}"))
+        .clone()
+}
+
+fn resolve_git_whose_exe() -> Result<PathBuf, String> {
+    if let Some(exe) = option_env!("CARGO_BIN_EXE_git-whose") {
+        return Ok(PathBuf::from(exe));
+    }
+
+    // `required-features` on the bin target means Cargo may skip setting
+    // `CARGO_BIN_EXE_git-whose` for integration tests, so build it explicitly.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let status = Command::new("cargo")
+        .current_dir(&manifest_dir)
+        .args(["build", "--bin", "git-whose", "--features", "git-whose"])
+        .status()
+        .map_err(|err| format!("failed to spawn cargo build for git-whose: {err}"))?;
+
+    if !status.success() {
+        return Err(format!(
+            "cargo build --bin git-whose --features git-whose failed with status {status}"
+        ));
+    }
+
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest_dir.join("target"));
+
+    Ok(target_dir
+        .join("debug")
+        .join(format!("git-whose{}", std::env::consts::EXE_SUFFIX)))
+}

--- a/tests/whose.rs
+++ b/tests/whose.rs
@@ -1,11 +1,14 @@
 #[path = "common/bare_multi.rs"]
 mod bare_multi;
+#[path = "common/bin.rs"]
+mod bin;
 #[path = "common/git_worktree.rs"]
 mod git_worktree;
 
 use std::process::Command;
 
 use bare_multi::bare_repo_with_committed_files;
+use bin::git_whose_exe;
 use git_worktree::{git_add, git_init, mkdir_p, write};
 use tempfile::TempDir;
 
@@ -26,8 +29,7 @@ fn git_whose_prints_owners_for_indexed_paths() {
     git_add(&repo, ".github/CODEOWNERS");
     git_add(&repo, "src/lib.rs");
 
-    let exe = std::env::var("CARGO_BIN_EXE_git-whose")
-        .expect("cargo test sets CARGO_BIN_EXE_git-whose when the binary is built");
+    let exe = git_whose_exe();
     let out = Command::new(exe)
         .current_dir(root)
         .args(["src/lib.rs"])
@@ -61,8 +63,7 @@ fn git_whose_prints_owners_for_bare_repo_head_tree() {
         ],
     );
 
-    let exe = std::env::var("CARGO_BIN_EXE_git-whose")
-        .expect("cargo test sets CARGO_BIN_EXE_git-whose when the binary is built");
+    let exe = git_whose_exe();
     let out = Command::new(exe)
         .env("GIT_DIR", git_dir.canonicalize().unwrap())
         .current_dir(root)


### PR DESCRIPTION
`cargo test` fails in the `whose` integration test because it assumes Cargo always sets `CARGO_BIN_EXE_git-whose`.

Current failure:

```text
thread 'git_whose_prints_owners_for_indexed_paths' panicked at tests/whose.rs:30:10:
cargo test sets CARGO_BIN_EXE_git-whose when the binary is built: NotPresent
```

and

```text
thread 'git_whose_prints_owners_for_bare_repo_head_tree' panicked at tests/whose.rs:65:10:
cargo test sets CARGO_BIN_EXE_git-whose when the binary is built: NotPresent
```

Cause:

`git-whose` is declared in `Cargo.toml` with:

```toml
[[bin]]
name = "git-whose"
path = "bin/whose.rs"
required-features = ["git-whose"]
```

Because the binary target is gated by `required-features`, the integration test cannot rely on Cargo providing `CARGO_BIN_EXE_git-whose` during `cargo test`.

The latent issue was introduced when per-binary `required-features` were added in commit `bb35492` (`chore(*): allow selective build of binaries`). It became visible later when `tests/whose.rs` was added.

Steps to reproduce:

1. Run `cargo test`
2. Observe failure in `tests/whose.rs`

Expected behavior:

`cargo test` should pass, and the `whose` integration test should be able to invoke `git-whose` reliably.

Actual behavior:

The test fails before invoking the binary because `CARGO_BIN_EXE_git-whose` is missing.