### PR TITLE
perf(git-whose): reduce use of iter and allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,7 @@ default = ["git-dah", "git-stale", "git-whose"]
 git-dah = []
 git-stale = []
 git-whose = []
+
+[[bench]]
+name = "codeowners"
+harness = false

--- a/benches/codeowners.rs
+++ b/benches/codeowners.rs
@@ -1,0 +1,50 @@
+use std::{hint::black_box, time::Instant};
+
+use git_toolbox::github::codeowners::CodeOwners;
+
+fn main() {
+    let data = fixture(5_000);
+    let codeowners = CodeOwners::<()>::try_from_bufread(data.as_bytes()).unwrap();
+    let paths = [
+        "apps/service-1/src/lib.rs",
+        "apps/service-20/src/main.rs",
+        "docs/guide/setup.md",
+        "scripts/release.sh",
+        "deep/nested/path/file.txt",
+    ];
+
+    bench("parse_5000_rules", 20, || {
+        black_box(CodeOwners::<()>::try_from_bufread(data.as_bytes()).unwrap());
+    });
+    bench("find_owners_5000_rules", 100_000, || {
+        for path in paths {
+            black_box(codeowners.find_owners(black_box(path)));
+        }
+    });
+    bench("debug_5000_rules", 20_000, || {
+        for path in paths {
+            black_box(codeowners.debug(black_box(path)).count());
+        }
+    });
+}
+
+fn bench(name: &str, iterations: usize, mut f: impl FnMut()) {
+    let start = Instant::now();
+    for _ in 0..iterations {
+        f();
+    }
+    let elapsed = start.elapsed();
+    let per_iter = elapsed / iterations as u32;
+    println!("{name}: total={elapsed:?} iter={iterations} per_iter={per_iter:?}");
+}
+
+fn fixture(rule_count: usize) -> String {
+    let mut out = String::with_capacity(rule_count * 32);
+    for i in 0..rule_count {
+        out.push_str(&format!("apps/service-{i}/ @team-{i}\n"));
+    }
+    out.push_str("docs/** @docs-team\n");
+    out.push_str("*.rs @rust-team\n");
+    out.push_str("* @fallback\n");
+    out
+}

--- a/src/github/codeowners.rs
+++ b/src/github/codeowners.rs
@@ -230,6 +230,12 @@ fn blob_for_codeowners_path<'a>(
 }
 
 impl<D: DebugInfo> CodeOwners<D> {
+    fn find_last_matching_entry_index(&self, path: &str) -> Option<usize> {
+        self.entries
+            .iter()
+            .rposition(|entry| entry.pattern.is_match(path))
+    }
+
     /// Parse CODEOWNERS file data in buffer.
     ///
     /// Examples
@@ -287,28 +293,21 @@ impl<D: DebugInfo> CodeOwners<D> {
     }
 
     pub fn debug<'a>(&'a self, path: &str) -> impl Iterator<Item = Match<'a, D>> {
+        let path = path.to_owned();
+        let effective = self.find_last_matching_entry_index(&path);
         self.entries
             .iter()
-            .filter(|&entry| entry.pattern.is_match(path))
-            .rev()
             .enumerate()
-            .map(|(nth, entry)| Match {
+            .filter(move |(_, entry)| entry.pattern.is_match(&path))
+            .map(move |(idx, entry)| Match {
                 entry,
-                effective: nth == 0,
+                effective: Some(idx) == effective,
             })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
     }
 
     /// Find owners for matching path.
     pub fn find_owners(&self, path: &str) -> Option<&Vec<String>> {
-        let entry = self
-            .entries
-            .iter()
-            .rev()
-            .find(|&entry| entry.pattern.is_match(path));
-
-        entry.map(|entry| &entry.owners)
+        self.find_last_matching_entry_index(path)
+            .map(|idx| &self.entries[idx].owners)
     }
 }

--- a/tests/codeowners.rs
+++ b/tests/codeowners.rs
@@ -130,3 +130,19 @@ fn codeowner_try_from_repo_works_for_bare_repository(#[case] path: &str) {
         Some(&vec![String::from("rust-team")])
     );
 }
+
+#[test]
+fn codeowner_debug_marks_only_last_match_effective() {
+    let co = CodeOwners::<()>::try_from_bufread(
+        &b"*.rs @rust-team\nsrc/** @src-team\nsrc/lib.rs @lib-team\n"[..],
+    )
+    .unwrap();
+
+    let matches = co.debug("src/lib.rs").collect::<Vec<_>>();
+
+    assert_eq!(matches.len(), 3);
+    assert!(!matches[0].is_effective());
+    assert!(!matches[1].is_effective());
+    assert!(matches[2].is_effective());
+    assert_eq!(matches[2].owners(), &vec![String::from("@lib-team")]);
+}


### PR DESCRIPTION
Refactor CODEOWNERS matching to share last-match lookup between find_owners and debug. Ensure debug output preserves entry order while marking only the final matching rule as effective.

This change reduces use of iterator and Vec allocation done by `collect`.
