### PR TITLE
feat(git-stale): add `--remote` to operate tracking branches

### DIFF
--- a/bin/stale.rs
+++ b/bin/stale.rs
@@ -377,7 +377,10 @@ mod tests {
     use clap::Parser;
     use git2::{BranchType, ConfigLevel, Oid, Repository, Signature};
     use git_toolbox::git::RemoteRef;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
 
     fn create_repo() -> Result<(TempDir, Repository), Box<dyn std::error::Error>> {
         let tmpdir = TempDir::new()?;
@@ -521,6 +524,7 @@ mod tests {
         dir: &std::path::Path,
         f: impl FnOnce() -> Result<T, Box<dyn std::error::Error>>,
     ) -> Result<T, Box<dyn std::error::Error>> {
+        let _cwd_lock = CWD_LOCK.lock().expect("cwd lock should not be poisoned");
         let cwd = std::env::current_dir()?;
         std::env::set_current_dir(dir)?;
         let result = f();

--- a/bin/stale.rs
+++ b/bin/stale.rs
@@ -2,16 +2,22 @@ use chrono::{DateTime, Local};
 use clap::Parser;
 use git2::{Branch, BranchType, PushOptions, RemoteCallbacks, Repository};
 use git_toolbox::{
-    config::Configuration, config::ProtectedBranches, git::GitTime, reltime::Reltime,
+    config::Configuration, config::ProtectedBranches, git::GitTime, git::RemoteRef,
+    reltime::Reltime,
 };
 use log::{error, info, warn};
-use std::{collections::HashMap, error::Error, process::exit};
+use std::{collections::HashMap, error::Error, io, process::exit};
 
 #[derive(Parser)]
 #[command(
     about = "List or delete stale branches",
     long_about = None)]
 struct Cli {
+    #[arg(
+        long,
+        help = "Select origin remote-tracking branches instead of local branches"
+    )]
+    remote: bool,
     #[arg(short, long, help = "Perform deletion of selected branches")]
     delete: bool,
     #[arg(
@@ -43,6 +49,14 @@ enum Command {
     ListLocalBranches {
         repo: Repository,
         visitor: LocalBranchVisitor,
+    },
+    DeleteRemoteBranches {
+        repo: Repository,
+        visitor: RemoteBranchVisitor,
+    },
+    ListRemoteBranches {
+        repo: Repository,
+        visitor: RemoteBranchVisitor,
     },
 }
 
@@ -111,6 +125,43 @@ impl Command {
                     Ok(())
                 })
             }
+            Self::DeleteRemoteBranches { repo, visitor } => {
+                let refspecs = visitor.for_each_branches(
+                    &repo,
+                    Vec::new(),
+                    |mut refspecs, remote_ref, _| {
+                        info!(
+                            "branch '{}' will be deleted from {}",
+                            remote_ref.branch(),
+                            remote_ref.remote()
+                        );
+                        refspecs.push(format!(":{}", remote_ref.branch()));
+                        Ok(refspecs)
+                    },
+                )?;
+                let mut remote = repo.find_remote("origin")?;
+                let mut callbacks = RemoteCallbacks::new();
+                callbacks.push_update_reference(|refname, status| {
+                    if let Some(error) = status {
+                        warn!("push failed: {refname}, status = {error}");
+                    } else {
+                        info!("pushed: {refname}");
+                    }
+                    Ok(())
+                });
+                let mut push_options = PushOptions::new();
+                push_options.remote_callbacks(callbacks);
+                if let Err(e) = remote.push(refspecs.as_slice(), Some(&mut push_options)) {
+                    warn!("failed to remove branches from origin: {e}")
+                }
+                Ok(())
+            }
+            Self::ListRemoteBranches { repo, visitor } => {
+                visitor.for_each_branches(&repo, (), |_, remote_ref, _| {
+                    println!("{}/{}", remote_ref.remote(), remote_ref.branch());
+                    Ok(())
+                })
+            }
         }
     }
 }
@@ -119,6 +170,13 @@ struct LocalBranchVisitor {
     since: Option<DateTime<Local>>,
     branches: Vec<String>,
     protected_branches: Option<ProtectedBranches>,
+}
+
+struct RemoteBranchVisitor {
+    since: DateTime<Local>,
+    branches: Vec<String>,
+    protected_branches: Option<ProtectedBranches>,
+    default_branch: Option<String>,
 }
 
 impl LocalBranchVisitor {
@@ -183,25 +241,118 @@ impl LocalBranchVisitor {
     }
 }
 
+impl RemoteBranchVisitor {
+    fn for_each_branches<S, F: Fn(S, RemoteRef, Branch<'_>) -> Result<S, Box<dyn Error>>>(
+        &self,
+        repo: &Repository,
+        init: S,
+        f: F,
+    ) -> Result<S, Box<dyn Error>> {
+        let mut st = init;
+        for branch in repo.branches(Some(BranchType::Remote))? {
+            let (branch, _) = branch?;
+            let Some(remote_ref_name) = branch.get().name() else {
+                continue;
+            };
+            let remote_ref = RemoteRef::new(remote_ref_name.to_owned())?;
+
+            if !self.match_branch(&remote_ref)? {
+                continue;
+            }
+
+            let commit = branch.get().peel_to_commit()?;
+            let commit_time: GitTime = commit.time().into();
+
+            if self.since > commit_time.into() {
+                st = f(st, remote_ref, branch)?;
+            }
+        }
+
+        Ok(st)
+    }
+
+    fn match_branch(&self, branch: &RemoteRef) -> Result<bool, Box<dyn Error>> {
+        if branch.remote() != "origin" {
+            return Ok(false);
+        }
+
+        let branch_name = branch.branch();
+        if branch_name == "HEAD" {
+            info!("branch 'origin/HEAD' ignored. NOTE: remote HEAD is always ignored.");
+            Ok(false)
+        } else if self
+            .default_branch
+            .as_ref()
+            .is_some_and(|default_branch| default_branch == branch_name)
+        {
+            info!("branch 'origin/{branch_name}' ignored. NOTE: default branch is always ignored.");
+            Ok(false)
+        } else if self
+            .protected_branches
+            .as_ref()
+            .is_some_and(|protected| protected.is_match(branch_name))
+        {
+            info!(
+                "branch 'origin/{branch_name}' ignored. NOTE: protected branches from dah.protectedbranch are always ignored."
+            );
+            Ok(false)
+        } else if self.branches.is_empty() {
+            Ok(true)
+        } else {
+            Ok(self
+                .branches
+                .iter()
+                .any(|prefix| branch_name.starts_with(prefix)))
+        }
+    }
+}
+
+fn usage_error(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(io::Error::other(message.into()))
+}
+
 impl Cli {
     fn into_command(self) -> Result<Command, Box<dyn Error>> {
         let repo = Repository::open_from_env()?;
         let config = repo.config()?;
-        let protected_branches = Configuration::new(&config).dah_protected_branches()?;
+        let configuration = Configuration::new(&config);
+        let protected_branches = configuration.dah_protected_branches()?;
         let now = Local::now();
         let since = self.since.map(|s| now - s);
-        let visitor = LocalBranchVisitor {
-            since,
-            branches: self.branches,
-            protected_branches,
-        };
+        let command = if self.remote {
+            let since = since.ok_or_else(|| usage_error("--remote requires --since"))?;
+            if self.delete && !self.push {
+                return Err(usage_error("--remote --delete requires --push"));
+            }
+            repo.find_remote("origin")
+                .map_err(|_| usage_error("origin remote does not exist"))?;
 
-        let command = if self.delete && self.push {
-            Command::DeleteUpstreamBranches { repo, visitor }
-        } else if self.delete {
-            Command::DeleteLocalBranches { repo, visitor }
+            let visitor = RemoteBranchVisitor {
+                since,
+                branches: self.branches,
+                protected_branches,
+                default_branch: configuration.init_default_branch()?,
+            };
+
+            if self.delete {
+                Command::DeleteRemoteBranches { repo, visitor }
+            } else {
+                Command::ListRemoteBranches { repo, visitor }
+            }
         } else {
-            Command::ListLocalBranches { repo, visitor }
+            let visitor = LocalBranchVisitor {
+                since,
+                branches: self.branches,
+                protected_branches,
+            };
+
+            if self.delete && self.push {
+                Command::DeleteUpstreamBranches { repo, visitor }
+            } else if self.delete {
+                Command::DeleteLocalBranches { repo, visitor }
+            } else {
+                Command::ListLocalBranches { repo, visitor }
+            }
         };
 
         Ok(command)
@@ -221,9 +372,11 @@ fn main() -> ! {
 
 #[cfg(test)]
 mod tests {
-    use super::LocalBranchVisitor;
+    use super::{Cli, Command, LocalBranchVisitor, RemoteBranchVisitor};
     use chrono::{Duration, Local};
-    use git2::{BranchType, ConfigLevel, Repository, Signature};
+    use clap::Parser;
+    use git2::{BranchType, ConfigLevel, Oid, Repository, Signature};
+    use git_toolbox::git::RemoteRef;
     use tempfile::TempDir;
 
     fn create_repo() -> Result<(TempDir, Repository), Box<dyn std::error::Error>> {
@@ -291,6 +444,23 @@ mod tests {
         })
     }
 
+    fn create_remote_branch_visitor(
+        repo: &Repository,
+    ) -> Result<RemoteBranchVisitor, Box<dyn std::error::Error>> {
+        repo.config()?
+            .open_level(ConfigLevel::Local)?
+            .set_str("dah.protectedbranch", "develop:release/*")?;
+        let config = repo.config()?;
+        let config = git_toolbox::config::Configuration::new(&config);
+        let protected_branches = config.dah_protected_branches()?;
+        Ok(RemoteBranchVisitor {
+            since: Local::now() + Duration::days(1),
+            branches: Vec::new(),
+            protected_branches,
+            default_branch: config.init_default_branch()?,
+        })
+    }
+
     fn track_branch(
         repo: &Repository,
         branch_name: &str,
@@ -316,6 +486,46 @@ mod tests {
         local_branch.set_upstream(Some(&format!("origin/{branch_name}")))?;
 
         Ok(())
+    }
+
+    fn create_remote_tracking_branch(
+        repo: &Repository,
+        branch_name: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let branch = repo.find_branch(branch_name, BranchType::Local)?;
+        let target = branch
+            .get()
+            .target()
+            .expect("local branch should point to a commit");
+        create_remote_tracking_branch_from_target(repo, branch_name, target)
+    }
+
+    fn create_remote_tracking_branch_from_target(
+        repo: &Repository,
+        branch_name: &str,
+        target: Oid,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if repo.find_remote("origin").is_err() {
+            repo.remote("origin", "file:///tmp/origin.git")?;
+        }
+        repo.reference(
+            &format!("refs/remotes/origin/{branch_name}"),
+            target,
+            true,
+            "create remote-tracking ref",
+        )?;
+        Ok(())
+    }
+
+    fn with_cwd<T>(
+        dir: &std::path::Path,
+        f: impl FnOnce() -> Result<T, Box<dyn std::error::Error>>,
+    ) -> Result<T, Box<dyn std::error::Error>> {
+        let cwd = std::env::current_dir()?;
+        std::env::set_current_dir(dir)?;
+        let result = f();
+        std::env::set_current_dir(cwd)?;
+        result
     }
 
     #[test]
@@ -424,6 +634,194 @@ mod tests {
         })?;
 
         assert_eq!(vec!["feature/old".to_owned()], selected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_head_is_always_ignored() -> Result<(), Box<dyn std::error::Error>> {
+        let (_tmpdir, repo) = create_repo()?;
+        let main = repo.find_branch("main", BranchType::Local)?;
+        let main = main
+            .get()
+            .target()
+            .expect("local branch should point to a commit");
+        create_remote_tracking_branch_from_target(&repo, "HEAD", main)?;
+        let v = create_remote_branch_visitor(&repo)?;
+        let remote_ref = RemoteRef::new("refs/remotes/origin/HEAD".to_owned())?;
+
+        assert!(!v.match_branch(&remote_ref)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_default_branch_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+        let (_tmpdir, repo) = create_repo()?;
+        repo.config()?
+            .open_level(ConfigLevel::Local)?
+            .set_str("init.defaultbranch", "main")?;
+        create_remote_tracking_branch(&repo, "main")?;
+        let v = create_remote_branch_visitor(&repo)?;
+        let remote_ref = RemoteRef::new("refs/remotes/origin/main".to_owned())?;
+
+        assert!(!v.match_branch(&remote_ref)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_protected_branches_are_ignored() -> Result<(), Box<dyn std::error::Error>> {
+        let (_tmpdir, repo) = create_repo()?;
+        create_remote_tracking_branch(&repo, "develop")?;
+        let v = create_remote_branch_visitor(&repo)?;
+        let remote_ref = RemoteRef::new("refs/remotes/origin/develop".to_owned())?;
+
+        assert!(!v.match_branch(&remote_ref)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_branch_matches_prefix_filter_on_short_name() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (_tmpdir, repo) = create_repo()?;
+        create_remote_tracking_branch(&repo, "feature/old")?;
+        let mut v = create_remote_branch_visitor(&repo)?;
+        v.branches = vec!["feature/".to_owned()];
+        let remote_ref = RemoteRef::new("refs/remotes/origin/feature/old".to_owned())?;
+
+        assert!(v.match_branch(&remote_ref)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_for_each_branches_lists_origin_tracking_refs(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_tmpdir, repo) = create_repo()?;
+        create_remote_tracking_branch(&repo, "feature/old")?;
+        let v = create_remote_branch_visitor(&repo)?;
+
+        let selected = v.for_each_branches(&repo, Vec::new(), |mut names, remote_ref, _| {
+            names.push(format!("{}/{}", remote_ref.remote(), remote_ref.branch()));
+            Ok(names)
+        })?;
+
+        assert_eq!(vec!["origin/feature/old".to_owned()], selected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_for_each_branches_ignores_non_origin_tracking_refs(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_tmpdir, repo) = create_repo()?;
+        let feature = repo.find_branch("feature/old", BranchType::Local)?;
+        let feature = feature
+            .get()
+            .target()
+            .expect("local branch should point to a commit");
+        repo.remote("upstream", "file:///tmp/upstream.git")?;
+        repo.reference(
+            "refs/remotes/upstream/feature/old",
+            feature,
+            true,
+            "create remote-tracking ref",
+        )?;
+        let v = create_remote_branch_visitor(&repo)?;
+
+        let selected = v.for_each_branches(&repo, Vec::new(), |mut names, remote_ref, _| {
+            names.push(format!("{}/{}", remote_ref.remote(), remote_ref.branch()));
+            Ok(names)
+        })?;
+
+        assert!(selected.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_rejects_remote_without_since() -> Result<(), Box<dyn std::error::Error>> {
+        let (tmpdir, _repo) = create_repo()?;
+        let result = with_cwd(tmpdir.path(), || {
+            let cli = Cli::try_parse_from(["git-stale", "--remote"])?;
+            cli.into_command()
+        });
+        let err = match result {
+            Ok(_) => panic!("should reject missing --since"),
+            Err(err) => err,
+        };
+
+        assert_eq!("--remote requires --since", err.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_rejects_remote_delete_without_push() -> Result<(), Box<dyn std::error::Error>> {
+        let (tmpdir, repo) = create_repo()?;
+        repo.remote("origin", "file:///tmp/origin.git")?;
+        let result = with_cwd(tmpdir.path(), || {
+            let cli = Cli::try_parse_from(["git-stale", "--remote", "--since", "3mo", "--delete"])?;
+            cli.into_command()
+        });
+        let err = match result {
+            Ok(_) => panic!("should reject remote delete without push"),
+            Err(err) => err,
+        };
+
+        assert_eq!("--remote --delete requires --push", err.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_rejects_remote_mode_without_origin_remote() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::new()?;
+        let _repo = Repository::init(tmpdir.path())?;
+        let result = with_cwd(tmpdir.path(), || {
+            let cli = Cli::try_parse_from(["git-stale", "--remote", "--since", "3mo"])?;
+            cli.into_command()
+        });
+        let err = match result {
+            Ok(_) => panic!("should reject missing origin"),
+            Err(err) => err,
+        };
+
+        assert_eq!("origin remote does not exist", err.to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn local_mode_behavior_is_unchanged() -> Result<(), Box<dyn std::error::Error>> {
+        let (tmpdir, _repo) = create_repo()?;
+        let command = with_cwd(tmpdir.path(), || {
+            let cli = Cli::try_parse_from(["git-stale", "--delete"])?;
+            cli.into_command()
+        })?;
+
+        assert!(matches!(command, Command::DeleteLocalBranches { .. }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn remote_delete_push_builds_origin_deletion_refspec() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (_tmpdir, repo) = create_repo()?;
+        repo.remote("origin", "file:///tmp/origin.git")?;
+        create_remote_tracking_branch(&repo, "feature/old")?;
+        let mut visitor = create_remote_branch_visitor(&repo)?;
+        visitor.branches = vec!["feature/".to_owned()];
+        let refspecs =
+            visitor.for_each_branches(&repo, Vec::new(), |mut refspecs, remote_ref, _| {
+                refspecs.push(format!(":{}", remote_ref.branch()));
+                Ok(refspecs)
+            })?;
+
+        assert_eq!(vec![":feature/old".to_owned()], refspecs);
 
         Ok(())
     }


### PR DESCRIPTION
# Add support for deleting remote branches via remote-tracking branches in `git-stale`

## Problem to Solve

Currently, `git-stale` only targets local branches.

```sh
git fetch origin very-old-branch
git stale --since 3mo
```

In this case, `very-old-branch` does not appear because it does not exist under `refs/heads/*`.

Today, the branch cannot be deleted unless a local branch is created explicitly from the remote-tracking branch.

```sh
git fetch origin very-old-branch
git branch --track very-old-branch refs/remotes/origin/very-old-branch

git stale --since 3mo
git stale --since 3mo --delete --push
```

This workflow is cumbersome. We want to handle already-fetched remote branches without creating local branches.

## Goal

Add a `--remote` option to `git-stale` so remote-tracking branches can be listed.

```sh
git fetch origin very-old-branch
git stale --remote --since 3mo
git stale --remote --since 3mo --delete --push
```

This makes it possible to inspect stale remote branches and delete them directly, without creating local branches first.

## Current Behavior

Today, `git-stale` behaves as follows:

- Only local branches are considered
- When `--since` is provided, branches whose tip commit time is older than the threshold are selected
- When `--since` is not provided, local branches without an upstream are selected
- `HEAD` is always excluded
- Branches matching `dah.protectedbranch` are always excluded
- `--delete --push` pushes a branch deletion to the upstream remote

Adding `--remote` must not change the existing behavior for local branches.

## Interface

### New Option

`--remote`

- Switch the listing target from local branches to remote-tracking branches
- Limit the initial target to `refs/remotes/origin/*`
- Do not handle local branches and remote-tracking branches at the same time

The initial implementation does not support selecting a remote by name.
If that becomes necessary later, we can consider `--remote <name>` or `--all-remotes` separately.

## Semantics

### Selection Target

When `--remote` is not specified:

- Keep the current behavior and target local branches

When `--remote` is specified:

- Target `refs/remotes/origin/*`
- Always exclude `refs/remotes/origin/HEAD`

### Stale Detection

Use the branch tip commit time to determine staleness for both local and remote branches.

- When `--since <SINCE>` is specified, select branches whose tip commit is older than that timestamp
- Do not use fetch time

When `--since` is not specified:

- For local branches, keep the current behavior and select branches without an upstream
- For remote branches, require `--since` to avoid introducing undefined behavior

In other words, `git stale --remote` should be treated as an error.

### Prefix Filter

Keep the positional `BRANCHES` arguments as a prefix filter.

- In local mode, evaluate them against the local branch name as today
- In remote mode, evaluate them against the short branch name such as `feature/foo`, not the full `origin/feature/foo`

For example, `git stale --remote --since 3mo feature/` should include `origin/feature/x`.

### Protected Branches

Apply `dah.protectedbranch` in `--remote` mode as well.

- Match against the short branch name
- For example, `develop:release/*` should exclude `origin/develop` and `origin/release/v1`

### Default Branch

Exclude the default branch in `--remote` mode as well.

Reasons:

- If remote branch deletion is supported, the tool should default to the safer behavior
- `git-stale` already follows the principle of excluding protected branches
- Excluding only `origin/HEAD` is not enough to prevent deletion of the default branch itself

Resolve the default branch name using the existing configuration-loading approach.

## Deletion Behavior

### Local Mode

When `--remote` is not specified, keep the existing deletion behavior.

- `--delete` deletes the local branch
- `--delete --push` pushes a branch deletion to the upstream remote

### Remote Mode

When `--remote` is specified, the deletion behavior should be:

- `--remote` only: list branches
- `--remote --delete`: error
- `--remote --delete --push`: delete the remote branch

Allowing `--remote --delete` would make it unclear whether the command means deleting the local remote-tracking ref or deleting the actual remote branch.
For that reason, remote-mode deletion should require `--push` so the meaning stays fixed.

Use the short branch name for the remote branch to delete.

For example, `refs/remotes/origin/feature/old` should be deleted by pushing `:feature/old` to `origin`.

## Output

For listing output, keep the current one-line-per-branch behavior.

- Local mode: `feature/old`
- Remote mode: `origin/feature/old`

In remote mode, including the remote name makes the origin of the target clearer.

## Errors

Treat the following as usage errors:

- `--remote` used without `--since`
- `--remote --delete` used without `--push`
- the `origin` remote does not exist

## Examples

Listing:

```sh
git fetch origin --prune
git stale --remote --since 3mo
```

Listing with a prefix:

```sh
git stale --remote --since 3mo feature/
```

Deleting remote branches:

```sh
git stale --remote --since 3mo --delete --push
```

## Tests To Add

- `--remote --since` lists `refs/remotes/origin/*`
- `refs/remotes/origin/HEAD` is always excluded
- the default branch is excluded in remote mode as well
- `dah.protectedbranch` is applied in remote mode as well
- the prefix filter is evaluated against the short branch name
- `--remote` alone returns an error
- `--remote --delete` returns an error
- `--remote --delete --push` sends a deletion refspec to `origin`
- existing local-mode behavior remains unchanged

## Non-goals

This change does not cover:

- specifying a remote other than `origin`
- scanning multiple remotes at the same time
- automatically running fetch
- using fetch time or reflog data for stale detection
